### PR TITLE
#62: ルーム一覧ページの実装

### DIFF
--- a/routes/rooms.js
+++ b/routes/rooms.js
@@ -3,9 +3,7 @@ const router = express.Router();
 const RoomController = require("../src/controllers/RoomController");
 const RoomModel = require('../src/models/Room');
 
-router.get("/", (req, res) => {
-  res.render("rooms/index");
-})
+router.get("/", RoomController.index);
 
 router.get("/new", (req, res) => {
   res.render("rooms/new");

--- a/src/controllers/RoomController.js
+++ b/src/controllers/RoomController.js
@@ -18,6 +18,16 @@ const RoomController = {
 
     res.status(201).redirect("/rooms/" + room.id);
   },
+
+  /**
+   * すべてのルームを表示する。
+   * @param {Request} req
+   * @param {Response} res
+   */
+  index: async (req, res) => {
+    const rooms = await RoomModel.findAll();
+    res.render("rooms/index", { rooms });
+  },
 };
 
 module.exports = RoomController

--- a/src/controllers/RoomController.js
+++ b/src/controllers/RoomController.js
@@ -28,4 +28,6 @@ const RoomController = {
     const rooms = await RoomModel.findAll();
     res.render("rooms/index", { rooms });
   },
+}
+
 module.exports = RoomController

--- a/src/models/Room.js
+++ b/src/models/Room.js
@@ -43,6 +43,20 @@ const RoomModel = {
   },
 
   /**
+   * すべてのルームを取得する。
+   * @returns {Object[]} ルームの配列
+   */
+  findAll: async () => {
+    const { data, error } = await supabase
+      .from('rooms')
+      .select('*');
+    if (error) {
+      throw new Error(`Room search failed: ${error.message}`);
+    }
+    return data;
+  },
+
+  /**
    * ルームidをもとに、ルームを検索する。
    * @param {string} id ルームid
    * @returns {Object} ルーム

--- a/tests/models/Room.test.js
+++ b/tests/models/Room.test.js
@@ -21,7 +21,15 @@ describe('RoomModel', () => {
       expect(room.user_id).toBe(userId);
 
       // delete after
-      await supabase.from('rooms').delete().match({ name: name });
+      await supabase.from('rooms').delete().eq("id", room.id);
+    })
+  })
+
+  describe("Room#findAll", () => {
+    it("正常に全てのルームを取得できるか", async () => {
+      const rooms = await RoomModel.findAll();
+      expect(rooms).not.toBeNull();
+      expect(rooms.length).toBe(10);
     })
   })
 
@@ -59,6 +67,9 @@ describe('RoomModel', () => {
       const updatedRoom = await RoomModel.update(room.id, updateData);
       expect(updatedRoom).not.toBeNull();
       expect(updatedRoom.name).toBe(updateData.name);
+
+      // delete after
+      await supabase.from('rooms').delete().eq("id", room.id);
     })
 
     // TODO: 異常系

--- a/views/rooms/index.ejs
+++ b/views/rooms/index.ejs
@@ -1,1 +1,17 @@
 
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>ルーム一覧</title>
+</head>
+<body>
+    <% for (const room of rooms) { %>
+        <a href="/rooms/<%= room.id %>"><%= room.name %></a>
+        <p><%= room.description %></p>
+
+        <hr>
+    <% } %>
+</body>
+</html>

--- a/views/rooms/index.ejs
+++ b/views/rooms/index.ejs
@@ -1,16 +1,1 @@
-<!DOCTYPE html>
-<html lang="ja">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>ボタンデザイン</title>
-    <link rel="stylesheet" href="/stylesheets/index.css">
-</head>
-<body>
-    <div class="button-container">
-        <button class="custom-button">ルーム作成</button>
-        <button class="custom-button">ルーム参加</button>
-    </div>
-</body>
-</html>
+

--- a/views/rooms/select-mode.ejs
+++ b/views/rooms/select-mode.ejs
@@ -1,12 +1,19 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="ja">
+
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>モード選択</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>操作選択</title>
+  <link rel="stylesheet" href="/stylesheets/index.css">
 </head>
+
 <body>
-  <a href="/rooms/new">ルーム作成</a>
-  <a href="/rooms">ルーム一覧</a>
+  <div class="button-container">
+    <button class="custom-button">ルーム作成</button>
+    <button class="custom-button">ルーム参加</button>
+  </div>
 </body>
+
 </html>

--- a/views/rooms/select-mode.ejs
+++ b/views/rooms/select-mode.ejs
@@ -11,8 +11,8 @@
 
 <body>
   <div class="button-container">
-    <button class="custom-button">ルーム作成</button>
-    <button class="custom-button">ルーム参加</button>
+    <a class="custom-button" href="/rooms/new">ルーム作成</a>
+    <a class="custom-button" href="/rooms/">ルーム参加</a>
   </div>
 </body>
 </html>


### PR DESCRIPTION
## 変更の概要 <!-- ここにはこのプルリクエストが何を変更するのか簡単に書いてください -->
<!-- 例: ログイン機能のバグ修正 -->
`/rooms` にルーム一覧ページを紐づけ、作成したルームの一覧を表示できるようにした。

## 関連するIssue <!-- 関連するIssue番号（あれば） -->
<!-- 例: #123 -->
#62 

## 変更内容 <!-- 具体的にどのような変更を加えたか書いてください -->
<!-- 例: ログインボタンが動作しない問題を修正しました -->
- `RoomModel.findAll` の実装
- `RoomController.index` を実装
- `/rooms/` に `RoomController.index` を紐づけ

## デバッグ方法 <!-- レビューのため、作成した機能をデバッグする手順を教えてください -->
<!-- 例:
1. ログインページを開く
2. 正しいユーザー名とパスワードを入力する
3. ログインボタンをクリックする
4. ダッシュボードページに移動することを確認する
-->
1. 任意のアカウントでログインする
2. 「ルーム参加」を押す
3. ルームの一覧が表示される

## チェックリスト <!-- プルリクエストを提出する前に確認する項目の括弧に「x」を入れてください -->
- [x] コードが正しく動作することを確認しました
- [ ] ドキュメントを更新しました（必要な場合）

## 備考 <!-- 他に伝えたいことがあれば書いてください -->
<!-- 例: 関連するリンクや参考資料 -->
