### PR TITLE
ルームごとに別のcanvas上に参加するように実装した

### DIFF
--- a/app.js
+++ b/app.js
@@ -13,11 +13,11 @@ const io = new Server(server);
 
 io.on("connection", (socket) => {
   console.log(`user connected: ${socket.id}`);
-  socket.broadcast.emit("join", { userSessionId: socket.id });
+  socket.broadcast.emit("join", { socketId: socket.id });
 
   socket.on("disconnect", () => {
     console.log(`user disconnected: ${socket.id}`);
-    socket.broadcast.emit("leave", { userSessionId: socket.id });
+    socket.broadcast.emit("leave", { socketId: socket.id });
   });
 });
 

--- a/app.js
+++ b/app.js
@@ -19,6 +19,10 @@ io.on("connection", (socket) => {
     console.log(`user disconnected: ${socket.id}`);
     socket.broadcast.emit("leave", { socketId: socket.id });
   });
+
+  socket.on("setFlag", (data) => {
+    socket.broadcast.emit("setFlag", { socketId: data.socketId, flag: data.flag, value: data.value });
+  });
 });
 
 const indexRouter = require('./routes/index');

--- a/app.js
+++ b/app.js
@@ -4,6 +4,12 @@ const express = require('express');
 const path = require('path');
 const cookieParser = require('cookie-parser');
 const logger = require('morgan');
+const { Server } = require('socket.io');
+const http = require('http');
+
+const app = express();
+const server = http.createServer(app);
+const io = new Server(server);
 
 const indexRouter = require('./routes/index');
 const authRouter = require('./routes/auth');
@@ -12,8 +18,6 @@ const roomRouter = require('./routes/rooms');
 const apiRouter = require('./routes/api');
 
 const authCheck = require('./src/middleware/authCheck');
-
-var app = express();
 
 // view engine setup
 app.set('views', path.join(__dirname, 'views'));
@@ -50,4 +54,4 @@ app.use(function(err, req, res, next) {
   res.render('error');
 });
 
-module.exports = app;
+module.exports = { app, server, io };

--- a/app.js
+++ b/app.js
@@ -17,6 +17,7 @@ io.on("connection", (socket) => {
 
   socket.on("disconnect", () => {
     console.log(`user disconnected: ${socket.id}`);
+    socket.broadcast.emit("leave", { userSessionId: socket.id });
   });
 });
 

--- a/app.js
+++ b/app.js
@@ -13,6 +13,7 @@ const io = new Server(server);
 
 io.on("connection", (socket) => {
   console.log(`user connected: ${socket.id}`);
+  socket.emit("initRoom", { socketIds: Array.from(io.sockets.sockets.keys()) });
   socket.broadcast.emit("join", { socketId: socket.id });
 
   socket.on("disconnect", () => {

--- a/app.js
+++ b/app.js
@@ -12,9 +12,10 @@ const server = http.createServer(app);
 const io = new Server(server);
 
 io.on("connection", (socket) => {
-  socket.on("join", (data) => {
-    const { roomId, userId } = data;
-    console.log(`user joined: ${userId} to room: ${roomId}`);
+  console.log(`user connected: ${socket.id}`);
+
+  socket.on("disconnect", () => {
+    console.log(`user disconnected: ${socket.id}`);
   });
 });
 
@@ -25,6 +26,7 @@ const roomRouter = require('./routes/rooms');
 const apiRouter = require('./routes/api');
 
 const authCheck = require('./src/middleware/authCheck');
+const { log } = require('console');
 
 // view engine setup
 app.set('views', path.join(__dirname, 'views'));

--- a/app.js
+++ b/app.js
@@ -11,6 +11,13 @@ const app = express();
 const server = http.createServer(app);
 const io = new Server(server);
 
+io.on("connection", (socket) => {
+  socket.on("join", (data) => {
+    const { roomId, userId } = data;
+    console.log(`user joined: ${userId} to room: ${roomId}`);
+  });
+});
+
 const indexRouter = require('./routes/index');
 const authRouter = require('./routes/auth');
 const userRouter = require('./routes/users');
@@ -28,7 +35,7 @@ app.use(express.json());
 app.use(express.urlencoded({ extended: false }));
 app.use(cookieParser());
 app.use(express.static(path.join(__dirname, 'public')));
-app.use(favicon(path.join(__dirname,'public','favicon.ico')));
+app.use(favicon(path.join(__dirname, 'public', 'favicon.ico')));
 
 app.use('/', indexRouter);
 app.use('/auth', authRouter);
@@ -39,12 +46,12 @@ app.use('/rooms', authCheck, roomRouter);
 
 
 // catch 404 and forward to error handler
-app.use(function(req, res, next) {
+app.use(function (req, res, next) {
   next(createError(404));
 });
 
 // error handler
-app.use(function(err, req, res, next) {
+app.use(function (err, req, res, next) {
   // set locals, only providing error in development
   res.locals.message = err.message;
   res.locals.error = req.app.get('env') === 'development' ? err : {};

--- a/app.js
+++ b/app.js
@@ -27,7 +27,7 @@ io.on("connection", (socket) => {
   });
 
   socket.on("setFlag", (data) => {
-    socket.broadcast.emit("setFlag", { socketId: data.socketId, flag: data.flag, value: data.value });
+    socket.to(data.roomId).emit("setFlag", { socketId: data.socketId, flag: data.flag, value: data.value });
   });
 
   socket.on("leave", (data) => {

--- a/app.js
+++ b/app.js
@@ -13,6 +13,7 @@ const io = new Server(server);
 
 io.on("connection", (socket) => {
   console.log(`user connected: ${socket.id}`);
+  socket.broadcast.emit("join", { userSessionId: socket.id });
 
   socket.on("disconnect", () => {
     console.log(`user disconnected: ${socket.id}`);

--- a/app.js
+++ b/app.js
@@ -13,8 +13,14 @@ const io = new Server(server);
 
 io.on("connection", (socket) => {
   console.log(`user connected: ${socket.id}`);
-  socket.emit("initRoom", { socketIds: Array.from(io.sockets.sockets.keys()) });
-  socket.broadcast.emit("join", { socketId: socket.id });
+
+  socket.on("join", (data) => {
+    const roomId = data.roomId;
+    socket.join(roomId);
+    socket.to(roomId).emit("join", { socketId: socket.id });
+    const roomSockets = Array.from(io.sockets.adapter.rooms.get(roomId) || []);
+    socket.emit("initRoom", { socketIds: roomSockets });
+  });
 
   socket.on("disconnect", () => {
     console.log(`user disconnected: ${socket.id}`);

--- a/app.js
+++ b/app.js
@@ -24,11 +24,16 @@ io.on("connection", (socket) => {
 
   socket.on("disconnect", () => {
     console.log(`user disconnected: ${socket.id}`);
-    socket.broadcast.emit("leave", { socketId: socket.id });
   });
 
   socket.on("setFlag", (data) => {
     socket.broadcast.emit("setFlag", { socketId: data.socketId, flag: data.flag, value: data.value });
+  });
+
+  socket.on("leave", (data) => {
+    const roomId = data.roomId;
+    socket.leave(roomId);
+    socket.to(roomId).emit("leave", { socketId: socket.id });
   });
 });
 

--- a/bin/www
+++ b/bin/www
@@ -4,9 +4,8 @@
  * Module dependencies.
  */
 
-var app = require('../app');
+var {app, server, io} = require('../app');
 var debug = require('debug')('waffle2:server');
-var http = require('http');
 
 /**
  * Get port from environment and store in Express.
@@ -14,12 +13,6 @@ var http = require('http');
 
 var port = normalizePort(process.env.PORT || '3000');
 app.set('port', port);
-
-/**
- * Create HTTP server.
- */
-
-var server = http.createServer(app);
 
 /**
  * Listen on provided port, on all network interfaces.

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "morgan": "~1.9.1",
         "nodemailer": "^6.9.13",
         "serve-favicon": "^2.5.0",
+        "socket.io": "^4.7.5",
         "uuid": "^9.0.1"
       },
       "devDependencies": {
@@ -1392,6 +1393,11 @@
         "@sinonjs/commons": "^3.0.0"
       }
     },
+    "node_modules/@socket.io/component-emitter": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
+      "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA=="
+    },
     "node_modules/@supabase/auth-js": {
       "version": "2.64.2",
       "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.64.2.tgz",
@@ -1498,6 +1504,19 @@
       "dev": true,
       "dependencies": {
         "@babel/types": "^7.20.7"
+      }
+    },
+    "node_modules/@types/cookie": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.4.1.tgz",
+      "integrity": "sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q=="
+    },
+    "node_modules/@types/cors": {
+      "version": "2.8.17",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.17.tgz",
+      "integrity": "sha512-8CGDvrBj1zgo2qE+oS3pOCyYNqCPryMWY2bGfwA0dcfopWGgxs+78df0Rs3rc9THP4JkOhLsAa+15VdpAqkcUA==",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/graceful-fs": {
@@ -1930,6 +1949,14 @@
           "url": "https://feross.org/support"
         }
       ]
+    },
+    "node_modules/base64id": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/base64id/-/base64id-2.0.0.tgz",
+      "integrity": "sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==",
+      "engines": {
+        "node": "^4.5.0 || >= 5.9"
+      }
     },
     "node_modules/basic-auth": {
       "version": "2.0.1",
@@ -2559,6 +2586,18 @@
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ=="
     },
+    "node_modules/cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/create-jest": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/create-jest/-/create-jest-29.7.0.tgz",
@@ -2863,6 +2902,55 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/engine.io": {
+      "version": "6.5.5",
+      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.5.5.tgz",
+      "integrity": "sha512-C5Pn8Wk+1vKBoHghJODM63yk8MvrO9EWZUfkAt5HAqIgPE4/8FF0PEGHXtEd40l223+cE5ABWuPzm38PHFXfMA==",
+      "dependencies": {
+        "@types/cookie": "^0.4.1",
+        "@types/cors": "^2.8.12",
+        "@types/node": ">=10.0.0",
+        "accepts": "~1.3.4",
+        "base64id": "2.0.0",
+        "cookie": "~0.4.1",
+        "cors": "~2.8.5",
+        "debug": "~4.3.1",
+        "engine.io-parser": "~5.2.1",
+        "ws": "~8.17.1"
+      },
+      "engines": {
+        "node": ">=10.2.0"
+      }
+    },
+    "node_modules/engine.io-parser": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.2.tgz",
+      "integrity": "sha512-RcyUFKA93/CXH20l4SoVvzZfrSDMOTUS3bWVpTt2FuFP+XYrL8i8oonHP7WInRyVHXh0n/ORtoeiE1os+8qkSw==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/engine.io/node_modules/debug": {
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.5.tgz",
+      "integrity": "sha512-pt0bNEmneDIvdL1Xsd9oDQ/wrQRkXDT4AUWlNZNPKvW5x/jyO9VFXkJUP07vQ2upmw5PlaITaPKc31jK13V+jg==",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/engine.io/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/env-paths": {
       "version": "2.2.1",
@@ -6040,6 +6128,107 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/socket.io": {
+      "version": "4.7.5",
+      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.7.5.tgz",
+      "integrity": "sha512-DmeAkF6cwM9jSfmp6Dr/5/mfMwb5Z5qRrSXLpo3Fq5SqyU8CMF15jIN4ZhfSwu35ksM1qmHZDQ/DK5XTccSTvA==",
+      "dependencies": {
+        "accepts": "~1.3.4",
+        "base64id": "~2.0.0",
+        "cors": "~2.8.5",
+        "debug": "~4.3.2",
+        "engine.io": "~6.5.2",
+        "socket.io-adapter": "~2.5.2",
+        "socket.io-parser": "~4.2.4"
+      },
+      "engines": {
+        "node": ">=10.2.0"
+      }
+    },
+    "node_modules/socket.io-adapter": {
+      "version": "2.5.5",
+      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.5.tgz",
+      "integrity": "sha512-eLDQas5dzPgOWCk9GuuJC2lBqItuhKI4uxGgo9aIV7MYbk2h9Q6uULEh8WBzThoI7l+qU9Ast9fVUmkqPP9wYg==",
+      "dependencies": {
+        "debug": "~4.3.4",
+        "ws": "~8.17.1"
+      }
+    },
+    "node_modules/socket.io-adapter/node_modules/debug": {
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.5.tgz",
+      "integrity": "sha512-pt0bNEmneDIvdL1Xsd9oDQ/wrQRkXDT4AUWlNZNPKvW5x/jyO9VFXkJUP07vQ2upmw5PlaITaPKc31jK13V+jg==",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/socket.io-adapter/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+    },
+    "node_modules/socket.io-parser": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.4.tgz",
+      "integrity": "sha512-/GbIKmo8ioc+NIWIhwdecY0ge+qVBSMdgxGygevmdHj24bsfgtCmcUUcQ5ZzcylGFHsN3k4HB4Cgkl96KVnuew==",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.3.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/socket.io-parser/node_modules/debug": {
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.5.tgz",
+      "integrity": "sha512-pt0bNEmneDIvdL1Xsd9oDQ/wrQRkXDT4AUWlNZNPKvW5x/jyO9VFXkJUP07vQ2upmw5PlaITaPKc31jK13V+jg==",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/socket.io-parser/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+    },
+    "node_modules/socket.io/node_modules/debug": {
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.5.tgz",
+      "integrity": "sha512-pt0bNEmneDIvdL1Xsd9oDQ/wrQRkXDT4AUWlNZNPKvW5x/jyO9VFXkJUP07vQ2upmw5PlaITaPKc31jK13V+jg==",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/socket.io/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/source-map": {
       "version": "0.6.1",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "morgan": "~1.9.1",
     "nodemailer": "^6.9.13",
     "serve-favicon": "^2.5.0",
+    "socket.io": "^4.7.5",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/public/scripts/handlers/handleKeyDown.js
+++ b/public/scripts/handlers/handleKeyDown.js
@@ -1,5 +1,5 @@
 import { gameState } from "../screen.js";
-import { socket } from "../main.js";
+import { socket, roomId } from "../main.js";
 
 export const handleKeyDown = (e) => {
   const player = gameState.objects.find((object) => object.id === socket.id);
@@ -20,5 +20,5 @@ export const handleKeyDown = (e) => {
 };
 
 const emitSetFlag = (flag, value) => {
-  socket.emit("setFlag", { socketId: socket.id, flag: flag, value: value });
+  socket.emit("setFlag", { roomId, socketId: socket.id, flag: flag, value: value });
 };

--- a/public/scripts/handlers/handleKeyDown.js
+++ b/public/scripts/handlers/handleKeyDown.js
@@ -1,13 +1,16 @@
-import { interactionState } from "../screen.js";
+import { gameState } from "../screen.js";
+import { socket } from "../main.js";
 
 export const handleKeyDown = (e) => {
+  const player = gameState.objects.find((object) => object.id === socket.id);
+
   if (e.key === "ArrowUp" || e.key === "w") {
-    interactionState.setFlag("up", true);
+    player.interactionState.setFlag("up", true);
   } else if (e.key === "ArrowDown" || e.key === "s") {
-    interactionState.setFlag("down", true);
+    player.interactionState.setFlag("down", true);
   } else if (e.key === "ArrowLeft" || e.key === "a") {
-    interactionState.setFlag("left", true);
+    player.interactionState.setFlag("left", true);
   } else if (e.key === "ArrowRight" || e.key === "d") {
-    interactionState.setFlag("right", true);
+    player.interactionState.setFlag("right", true);
   }
 };

--- a/public/scripts/handlers/handleKeyDown.js
+++ b/public/scripts/handlers/handleKeyDown.js
@@ -5,12 +5,20 @@ export const handleKeyDown = (e) => {
   const player = gameState.objects.find((object) => object.id === socket.id);
 
   if (e.key === "ArrowUp" || e.key === "w") {
+    emitSetFlag("up", true);
     player.interactionState.setFlag("up", true);
   } else if (e.key === "ArrowDown" || e.key === "s") {
+    emitSetFlag("down", true);
     player.interactionState.setFlag("down", true);
   } else if (e.key === "ArrowLeft" || e.key === "a") {
+    emitSetFlag("left", true);
     player.interactionState.setFlag("left", true);
   } else if (e.key === "ArrowRight" || e.key === "d") {
+    emitSetFlag("right", true);
     player.interactionState.setFlag("right", true);
   }
+};
+
+const emitSetFlag = (flag, value) => {
+  socket.emit("setFlag", { socketId: socket.id, flag: flag, value: value });
 };

--- a/public/scripts/handlers/handleKeyUp.js
+++ b/public/scripts/handlers/handleKeyUp.js
@@ -5,12 +5,20 @@ export const handleKeyUp = (e) => {
   const player = gameState.objects.find((object) => object.id === socket.id);
 
   if (e.key === "ArrowUp" || e.key === "w") {
+    emitSetFlag("up", false);
     player.interactionState.setFlag("up", false);
   } else if (e.key === "ArrowDown" || e.key === "s") {
+    emitSetFlag("down", false);
     player.interactionState.setFlag("down", false);
   } else if (e.key === "ArrowLeft" || e.key === "a") {
+    emitSetFlag("left", false);
     player.interactionState.setFlag("left", false);
   } else if (e.key === "ArrowRight" || e.key === "d") {
+    emitSetFlag("right", false);
     player.interactionState.setFlag("right", false);
   }
 }
+
+const emitSetFlag = (flag, value) => {
+  socket.emit("setFlag", { socketId: socket.id, flag: flag, value: value });
+};

--- a/public/scripts/handlers/handleKeyUp.js
+++ b/public/scripts/handlers/handleKeyUp.js
@@ -1,13 +1,16 @@
-import { interactionState } from "../screen.js";
+import { gameState } from "../screen.js";
+import { socket } from "../main.js";
 
 export const handleKeyUp = (e) => {
+  const player = gameState.objects.find((object) => object.id === socket.id);
+
   if (e.key === "ArrowUp" || e.key === "w") {
-    interactionState.setFlag("up", false);
+    player.interactionState.setFlag("up", false);
   } else if (e.key === "ArrowDown" || e.key === "s") {
-    interactionState.setFlag("down", false);
+    player.interactionState.setFlag("down", false);
   } else if (e.key === "ArrowLeft" || e.key === "a") {
-    interactionState.setFlag("left", false);
+    player.interactionState.setFlag("left", false);
   } else if (e.key === "ArrowRight" || e.key === "d") {
-    interactionState.setFlag("right", false);
+    player.interactionState.setFlag("right", false);
   }
 }

--- a/public/scripts/handlers/handleKeyUp.js
+++ b/public/scripts/handlers/handleKeyUp.js
@@ -1,5 +1,5 @@
 import { gameState } from "../screen.js";
-import { socket } from "../main.js";
+import { socket, roomId } from "../main.js";
 
 export const handleKeyUp = (e) => {
   const player = gameState.objects.find((object) => object.id === socket.id);
@@ -20,5 +20,5 @@ export const handleKeyUp = (e) => {
 }
 
 const emitSetFlag = (flag, value) => {
-  socket.emit("setFlag", { socketId: socket.id, flag: flag, value: value });
+  socket.emit("setFlag", { roomId, socketId: socket.id, flag: flag, value: value });
 };

--- a/public/scripts/main.js
+++ b/public/scripts/main.js
@@ -4,7 +4,7 @@ import { addPlayer, removePlayer, setPlayerFlag } from './screen.js';
 await initScreen();
 
 export const socket = io();
-const roomId = window.location.pathname.split("/")[2];
+export const roomId = window.location.pathname.split("/")[2];
 
 socket.on("connect", () => {
   console.log(`connected: ${socket.id}`);

--- a/public/scripts/main.js
+++ b/public/scripts/main.js
@@ -13,6 +13,12 @@ socket.on("join", (data) => {
   console.log(`user joined: ${data.socketId}`);
   addPlayer(data.socketId);
 });
+socket.on("initRoom", (data) => {
+  const socketIds = data.socketIds;
+  for(const socketId of socketIds) {
+    addPlayer(socketId);
+  } 
+});
 socket.on("setFlag", (data) => {
   setPlayerFlag(data.socketId, data.flag, data.value);
 });

--- a/public/scripts/main.js
+++ b/public/scripts/main.js
@@ -2,6 +2,10 @@ import { initScreen } from './screen.js';
 
 const socket = io();
 
+socket.on("join", (data) => {
+  console.log(`user joined: ${data.userSessionId}`);
+});
+
 window.addEventListener('beforeunload', () => {
   socket.disconnect();
 });

--- a/public/scripts/main.js
+++ b/public/scripts/main.js
@@ -1,6 +1,9 @@
 import { initScreen } from './screen.js';
 
 const socket = io();
-socket.emit("join", { roomId: "test", userId: "test" });
+
+window.addEventListener('beforeunload', () => {
+  socket.disconnect();
+});
 
 initScreen();

--- a/public/scripts/main.js
+++ b/public/scripts/main.js
@@ -5,6 +5,9 @@ const socket = io();
 socket.on("join", (data) => {
   console.log(`user joined: ${data.userSessionId}`);
 });
+socket.on("leave", (data) => {
+  console.log(`user leaved: ${data.userSessionId}`);
+});
 
 window.addEventListener('beforeunload', () => {
   socket.disconnect();

--- a/public/scripts/main.js
+++ b/public/scripts/main.js
@@ -1,0 +1,3 @@
+import { initScreen } from './screen.js';
+
+initScreen();

--- a/public/scripts/main.js
+++ b/public/scripts/main.js
@@ -1,16 +1,21 @@
 import { initScreen } from './screen.js';
+import { addPlayer, removePlayer } from './screen.js';
+
+await initScreen();
 
 const socket = io();
+addPlayer(socket.id);
 
 socket.on("join", (data) => {
   console.log(`user joined: ${data.userSessionId}`);
+  addPlayer(data.userSessionId);
 });
 socket.on("leave", (data) => {
   console.log(`user leaved: ${data.userSessionId}`);
+  removePlayer(data.userSessionId);
 });
 
 window.addEventListener('beforeunload', () => {
   socket.disconnect();
 });
 
-initScreen();

--- a/public/scripts/main.js
+++ b/public/scripts/main.js
@@ -4,9 +4,12 @@ import { addPlayer, removePlayer, setPlayerFlag } from './screen.js';
 await initScreen();
 
 export const socket = io();
+const roomId = window.location.pathname.split("/")[2];
 
 socket.on("connect", () => {
   console.log(`connected: ${socket.id}`);
+
+  socket.emit("join", { roomId });
 });
 socket.on("join", (data) => {
   console.log(`user joined: ${data.socketId}`);

--- a/public/scripts/main.js
+++ b/public/scripts/main.js
@@ -1,3 +1,6 @@
 import { initScreen } from './screen.js';
 
+const socket = io();
+socket.emit("join", { roomId: "test", userId: "test" });
+
 initScreen();

--- a/public/scripts/main.js
+++ b/public/scripts/main.js
@@ -7,7 +7,6 @@ export const socket = io();
 
 socket.on("connect", () => {
   console.log(`connected: ${socket.id}`);
-  addPlayer(socket.id);
 });
 socket.on("join", (data) => {
   console.log(`user joined: ${data.socketId}`);
@@ -17,7 +16,7 @@ socket.on("initRoom", (data) => {
   const socketIds = data.socketIds;
   for(const socketId of socketIds) {
     addPlayer(socketId);
-  } 
+  }
 });
 socket.on("setFlag", (data) => {
   setPlayerFlag(data.socketId, data.flag, data.value);

--- a/public/scripts/main.js
+++ b/public/scripts/main.js
@@ -3,16 +3,19 @@ import { addPlayer, removePlayer } from './screen.js';
 
 await initScreen();
 
-const socket = io();
-addPlayer(socket.id);
+export const socket = io();
 
+socket.on("connect", () => {
+  console.log(`connected: ${socket.id}`);
+  addPlayer(socket.id);
+});
 socket.on("join", (data) => {
-  console.log(`user joined: ${data.userSessionId}`);
-  addPlayer(data.userSessionId);
+  console.log(`user joined: ${data.socketId}`);
+  addPlayer(data.socketId);
 });
 socket.on("leave", (data) => {
-  console.log(`user leaved: ${data.userSessionId}`);
-  removePlayer(data.userSessionId);
+  console.log(`user leaved: ${data.socketId}`);
+  removePlayer(data.socketId);
 });
 
 window.addEventListener('beforeunload', () => {

--- a/public/scripts/main.js
+++ b/public/scripts/main.js
@@ -28,6 +28,9 @@ socket.on("leave", (data) => {
   console.log(`user leaved: ${data.socketId}`);
   removePlayer(data.socketId);
 });
+socket.on("disconnecting", () => {
+  socket.emit("leave", { socketId: socket.id, roomId });
+});
 
 window.addEventListener('beforeunload', () => {
   socket.disconnect();

--- a/public/scripts/main.js
+++ b/public/scripts/main.js
@@ -1,5 +1,5 @@
 import { initScreen } from './screen.js';
-import { addPlayer, removePlayer } from './screen.js';
+import { addPlayer, removePlayer, setPlayerFlag } from './screen.js';
 
 await initScreen();
 
@@ -12,6 +12,9 @@ socket.on("connect", () => {
 socket.on("join", (data) => {
   console.log(`user joined: ${data.socketId}`);
   addPlayer(data.socketId);
+});
+socket.on("setFlag", (data) => {
+  setPlayerFlag(data.socketId, data.flag, data.value);
 });
 socket.on("leave", (data) => {
   console.log(`user leaved: ${data.socketId}`);

--- a/public/scripts/objects/Player.js
+++ b/public/scripts/objects/Player.js
@@ -1,5 +1,5 @@
 import GameObject from "./GameObject.js";
-import { interactionState } from "../screen.js";
+import InteractionState from "../states/InteractionState.js";
 
 export const SPEED = 3;
 
@@ -7,17 +7,18 @@ export default class Player extends GameObject {
   constructor(id, x, y, width, height, imgPath) {
     super(x, y, width, height, imgPath);
     this.id = id;
+    this.interactionState = new InteractionState();
     this.color = "red";
   }
 
   update() {
-    if (interactionState.getFlag("up")) {
+    if (this.interactionState.getFlag("up")) {
       this.y -= SPEED;
-    } else if (interactionState.getFlag("down")) {
+    } else if (this.interactionState.getFlag("down")) {
       this.y += SPEED;
-    } else if (interactionState.getFlag("left")) {
+    } else if (this.interactionState.getFlag("left")) {
       this.x -= SPEED;
-    } else if (interactionState.getFlag("right")) {
+    } else if (this.interactionState.getFlag("right")) {
       this.x += SPEED;
     }
   }

--- a/public/scripts/objects/Player.js
+++ b/public/scripts/objects/Player.js
@@ -4,8 +4,9 @@ import { interactionState } from "../screen.js";
 export const SPEED = 3;
 
 export default class Player extends GameObject {
-  constructor(x, y, width, height, imgPath) {
+  constructor(id, x, y, width, height, imgPath) {
     super(x, y, width, height, imgPath);
+    this.id = id;
     this.color = "red";
   }
 

--- a/public/scripts/screen.js
+++ b/public/scripts/screen.js
@@ -51,6 +51,11 @@ export const removePlayer = (socketId) => {
   gameState.objects = gameState.objects.filter((object) => object.id !== socketId);
 }
 
+export const setPlayerFlag = (socketId, flag, value) => {
+  const player = getPlayer(socketId);
+  player.interactionState.setFlag(flag, value);
+}
+
 export const getPlayer = (socketId) => {
   return gameState.objects.find((object) => object.id === socketId);
 }

--- a/public/scripts/screen.js
+++ b/public/scripts/screen.js
@@ -1,5 +1,4 @@
 import GameState from "./states/GameState.js";
-import InteractionState from "./states/InteractionState.js";
 import CollidableObject from "./objects/CollidableObject.js";
 import Player from "./objects/Player.js";
 import { handleKeyDown } from "./handlers/handleKeyDown.js";
@@ -9,7 +8,6 @@ const canvas = document.getElementById("screen");
 const ctx = canvas.getContext("2d");
 
 export let gameState;
-export let interactionState;
 
 const draw = () => {
   ctx.clearRect(0, 0, canvas.width, canvas.height);
@@ -41,8 +39,6 @@ export const initScreen = async () => {
   gameState = new GameState();
   gameState.registerObject(new Player(0, 0, 10, 10));
   gameState.registerObjects(obstacles);
-
-  interactionState = new InteractionState();
   draw();
 }
 
@@ -53,6 +49,10 @@ export const addPlayer = (socketId) => {
 
 export const removePlayer = (socketId) => {
   gameState.objects = gameState.objects.filter((object) => object.id !== socketId);
+}
+
+export const getPlayer = (socketId) => {
+  return gameState.objects.find((object) => object.id === socketId);
 }
 
 const loadObstacles = async () => {

--- a/public/scripts/screen.js
+++ b/public/scripts/screen.js
@@ -46,6 +46,15 @@ export const initScreen = async () => {
   draw();
 }
 
+export const addPlayer = (socketId) => {
+  const player = new Player(socketId, 0, 0, 10, 10);
+  gameState.registerObject(player);
+}
+
+export const removePlayer = (socketId) => {
+  gameState.objects = gameState.objects.filter((object) => object.id !== socketId);
+}
+
 const loadObstacles = async () => {
   const response = await fetch('/api/map');
   if (!response.ok) {

--- a/public/scripts/screen.js
+++ b/public/scripts/screen.js
@@ -37,7 +37,6 @@ export const initScreen = async () => {
   });
 
   gameState = new GameState();
-  gameState.registerObject(new Player(0, 0, 10, 10));
   gameState.registerObjects(obstacles);
   draw();
 }

--- a/public/scripts/screen.js
+++ b/public/scripts/screen.js
@@ -30,7 +30,7 @@ const registerEvents = () => {
   window.addEventListener("keyup", handleKeyUp);
 }
 
-const init = async () => {
+export const initScreen = async () => {
   registerEvents();
 
   const obstaclesJson = await loadObstacles();
@@ -53,5 +53,3 @@ const loadObstacles = async () => {
   }
   return await response.json();
 };
-
-init();

--- a/src/models/VerificationToken.js
+++ b/src/models/VerificationToken.js
@@ -1,5 +1,4 @@
 const supabase = require('../libs/supabase');
-const { create } = require('./User');
 
 const VerificationTokenModel = {
   /**

--- a/views/rooms/show.ejs
+++ b/views/rooms/show.ejs
@@ -8,7 +8,7 @@
     <%= room.name %>
   </title>
   <link rel="stylesheet" href="/stylesheets/room/show.css">
-  <script type="module" src="/scripts/screen.js" defer></script>
+  <script type="module" src="/scripts/main.js" defer></script>
 </head>
 
 <body>

--- a/views/rooms/show.ejs
+++ b/views/rooms/show.ejs
@@ -8,6 +8,9 @@
     <%= room.name %>
   </title>
   <link rel="stylesheet" href="/stylesheets/room/show.css">
+
+  <!-- for canvas -->
+  <script src="/socket.io/socket.io.js"></script>
   <script type="module" src="/scripts/main.js" defer></script>
 </head>
 


### PR DESCRIPTION
## 変更の概要 <!-- ここにはこのプルリクエストが何を変更するのか簡単に書いてください -->
<!-- 例: ログイン機能のバグ修正 -->
これまで、ルームページに表示される canvas はどのルームも共通であり、ルームとして機能していなかった。
これを WebSocket によってルームごとに分離したことで、ルームごとの canvas がレンダリングできるようになった。

## 関連するIssue <!-- 関連するIssue番号（あれば） -->
<!-- 例: #123 -->

## デバッグ方法 <!-- レビューのため、作成した機能をデバッグする手順を教えてください -->
<!-- 例:
1. ログインページを開く
2. 正しいユーザー名とパスワードを入力する
3. ログインボタンをクリックする
4. ダッシュボードページに移動することを確認する
-->
1. ログインする
2. 適当なルームに参加する
3. タブをもう一枚開き、同じルームに参加する
  - [x] 双方の canvas に、ユーザーが参加していることを確認する
4. タブをもう一枚開き、別のルームに参加する
  - [x] 双方のキャンバスに、ユーザーが参加していないことを確認する

## チェックリスト <!-- プルリクエストを提出する前に確認する項目の括弧に「x」を入れてください -->
- [x] コードが正しく動作することを確認しました
- [ ] ドキュメントを更新しました（必要な場合）

## 備考 <!-- 他に伝えたいことがあれば書いてください -->
<!-- 例: 関連するリンクや参考資料 -->
